### PR TITLE
Bump lib-grimoire to 0.10.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure-grimoire/lib-grimoire "0.9.3"]
+                 [org.clojure-grimoire/lib-grimoire "0.10.2"]
                  [org.clojure/java.classpath "0.2.2"]
                  [org.clojure/tools.namespace "0.2.7"]
                  [me.arrdem/detritus "0.2.2"]]


### PR DESCRIPTION
This is necessary because of version problems caused by 0.9.3's outdated
guten-tag dependency.

Browsing lib-grimoire's Git history didn't reveal any critical changes,
neither did my manual tests. So it seems that the bump doesn't require
any changes, though I can't be sure.