### PR TITLE
Fix group key in :aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In `.lein/profiles.clj`, add lein-grim to your leiningen `:dependencies` and cre
    {:dependencies [org.clojure-grimoire/lein-grim <latest version>]}
    {:aliases
      {"grim" ["run" "-m" "grimoire.doc"
-              ,,:project/groupid
+              ,,:project/group
               ,,:project/name
               ,,:project/version
               ,,nil]}}}

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [org.clojure/tools.namespace "0.2.7"]
                  [me.arrdem/detritus "0.2.2"]]
   :aliases {"grim" ["run" "-m" "grimoire.doc"
-                    ,,:project/groupid
+                    ,,:project/group
                     ,,:project/name
                     ,,:project/version
                     ,,nil]})


### PR DESCRIPTION
Sorry for missing this one when I fixed :artifactId to :name. It also
has to be :group instead of :groupId. Here's an overview of how the
entries in project.clj end up:
https://github.com/technomancy/leiningen/tree/stable/lein-pprint
